### PR TITLE
feat: allow configurable port via environment variable

### DIFF
--- a/worker-server/src/main.rs
+++ b/worker-server/src/main.rs
@@ -15,7 +15,7 @@ type BoxBody = http_body_util::combinators::BoxBody<Bytes, hyper::Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
 

--- a/worker-server/src/main.rs
+++ b/worker-server/src/main.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::net::SocketAddr;
 
 use bytes::Bytes;
@@ -15,7 +16,8 @@ type BoxBody = http_body_util::combinators::BoxBody<Bytes, hyper::Error>;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
+    let port = env::var("PORT").unwrap_or_else(|_| "3000".to_string()).parse::<u16>()?;
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
 


### PR DESCRIPTION
In order to run multiple instances of worker server, we need to be able to configure the port via environment variable